### PR TITLE
fix: pin webpack below 5.107.0 to unbreak the production build

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,20 @@ jobs:
           jlpm install
           jlpm build
 
+      # The release workflow publishes from build:prod, which enables webpack
+      # plugins the dev build skips. `python -m build` below cannot cover this:
+      # skip-if-exists in pyproject.toml sees the dev output and skips the
+      # production build entirely. Run it explicitly so a prod-only failure
+      # fails CI instead of silently breaking the next release.
+      - name: Production build (matches the release path)
+        env:
+          YARN_ENABLE_IMMUTABLE_INSTALLS: 'false'
+          YARN_CHECKSUM_BEHAVIOR: update
+        run: |
+          set -eux
+          npm run build -w packages/core
+          npm run build:prod -w packages/extension
+
       - name: Test extension loads
         working-directory: packages/extension
         run: |

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "postcss": ">=8.5.10",
     "uuid": ">=11.1.1",
     "vite": ">=7.3.2",
-    "ws": ">=8.20.1"
+    "ws": ">=8.20.1",
+    "webpack": "5.106.2"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.49.0",


### PR DESCRIPTION
## Problem

The extension release path is broken. #93 merged but `publish-extension` failed, so **0.2.9 never reached PyPI** — the latest published version is still 0.2.8 from 2026-06-08.

```
HookWebpackError: Cannot read properties of undefined (reading 'trim')
    at WebpackModuleFileIterator.getActualFilename (license-webpack-plugin/dist/...)
```

## Root cause

webpack **5.107.0** (2026-05-20) changed the identifier `ProvideSharedModule` emits:

| webpack | identifier format |
|---|---|
| 5.106.2 | `provide module (scope) name@version` **` = `** `request` |
| 5.107.0 | `provide module (scope) name@version` **`\|`** `request` |

`license-webpack-plugin` parses that string positionally:

```js
if (filename.indexOf('provide module') === 0) {
    return filename.split('=')[1].trim();   // undefined.trim() once '=' is gone
}
```

The plugin ships this same code in **both v2 and v4**, and every `@jupyterlab/builder` 4.x depends on one of them — so neither pinning the builder back nor upgrading it avoids the crash. Holding webpack is the only fix available to us.

Verified locally: with webpack 5.106.2 the production build compiles and `python -m build` produces the 0.2.9 wheel.

## Why CI didn't catch it

Two gaps compounded:

1. CI ran `jlpm build` → `build:labextension:dev`. `license-webpack-plugin` only runs in **production** builds.
2. `python -m build` couldn't cover it either — `skip-if-exists` in `pyproject.toml` sees the dev output already present and skips the production build entirely (`INFO: Skip-if-exists file(s) found / Skipping build`).

So the release path has had no coverage at all. This PR adds an explicit `build:prod` step to `build.yml`.

## Changes

- `package.json` — pin `webpack: 5.106.2` in the existing `resolutions` block
- `.github/workflows/build.yml` — run `build:prod` so prod-only failures fail CI

`yarn.lock` is intentionally untouched: both workflows install with `YARN_ENABLE_IMMUTABLE_INSTALLS: false` and resolve fresh, and regenerating it here reformats all ~16k lines (yarn v1 → berry), which would bury the one-line fix.

## After merging

Re-run **Release & Publish** via `workflow_dispatch` with `target: extension` to ship 0.2.9 — release-please won't re-trigger on its own since the tag already exists.

## Follow-up

Unpin once `license-webpack-plugin` handles the new identifier format. Worth opening an issue upstream — this breaks every JupyterLab extension building against webpack ≥ 5.107.0.