### PR TITLE
fix(core): resolve relative image paths against the notebook's folder

### DIFF
--- a/packages/core/src/detection/category/color.ts
+++ b/packages/core/src/detection/category/color.ts
@@ -4,6 +4,8 @@ import {
   findMarkdownImages,
   findImgTags,
   extractImageUrl,
+  getNotebookDirectory,
+  joinNotebookPath,
 } from "../../utils/image-utils.js";
 
 function hexToRgb(hex: string): { r: number; g: number; b: number } {
@@ -70,10 +72,14 @@ async function getColorContrastInImage(
     }
     imageSource = dataUrl;
   } else {
-    // Regular image path (local or remote)
+    // Regular image path (local or remote). Relative paths resolve against the
+    // notebook's folder, not the notebook file itself.
     imageSource = imagePath.startsWith("http")
       ? imagePath
-      : `${baseUrl}files/${currentDirectoryPath}/${imagePath}`;
+      : `${baseUrl}files/${joinNotebookPath(
+          getNotebookDirectory(currentDirectoryPath),
+          imagePath,
+        )}`;
   }
 
   // Create canvas and load image

--- a/packages/core/src/detection/category/image.ts
+++ b/packages/core/src/detection/category/image.ts
@@ -4,6 +4,8 @@ import {
   findImgTags,
   findMarkdownImages,
   extractImageUrl,
+  getNotebookDirectory,
+  joinNotebookPath,
 } from "../../utils/image-utils.js";
 
 async function getTextInImage(
@@ -43,11 +45,14 @@ async function getTextInImage(
       }
       imageSource = dataUrl;
     } else {
+      // Relative paths resolve against the notebook's folder, not the
+      // notebook file itself.
+      const notebookDir = getNotebookDirectory(currentDirectoryPath);
       imageSource = imagePath.startsWith("http")
         ? imagePath
         : baseUrl
-          ? `${baseUrl}files/${currentDirectoryPath}/${imagePath}`
-          : `${currentDirectoryPath}/${imagePath}`; // Simple join for CLI
+          ? `${baseUrl}files/${joinNotebookPath(notebookDir, imagePath)}`
+          : joinNotebookPath(notebookDir, imagePath); // Simple join for CLI
     }
 
     // Load image using the processor (handles Browser vs Node differences)

--- a/packages/core/src/utils/image-utils.ts
+++ b/packages/core/src/utils/image-utils.ts
@@ -97,3 +97,33 @@ export function extractImageUrl(imageStr: string): string | null {
   }
   return null;
 }
+
+/**
+ * Resolve the directory that a notebook's relative image paths are relative to.
+ *
+ * Callers hand us the notebook's own path (e.g. JupyterLab's
+ * `NotebookPanel.context.path`), which points at the `.ipynb` file, not the
+ * folder holding it. Interpolating that directly produced URLs like
+ * `files/PS0/intro.ipynb/diagram.png`, which always 404.
+ *
+ * Returns "" for a notebook at the root, so callers join to `files/diagram.png`
+ * rather than `files//diagram.png`.
+ */
+export function getNotebookDirectory(notebookPath: string): string {
+  if (!notebookPath) {
+    return "";
+  }
+  const lastSlash = notebookPath.lastIndexOf("/");
+  return lastSlash === -1 ? "" : notebookPath.slice(0, lastSlash);
+}
+
+/**
+ * Join a notebook-relative directory and an image path without producing an
+ * empty segment when the directory is "" (notebook at the root).
+ */
+export function joinNotebookPath(
+  directory: string,
+  imagePath: string,
+): string {
+  return directory ? `${directory}/${imagePath}` : imagePath;
+}


### PR DESCRIPTION
Fixes #16

## Problem

Color contrast is never reported for images referenced by path:

```markdown
![sdsd](graphIssues3.png)      ← never detected
![x](attachment:793d92b6-...)  ← works
```

## Cause

Every caller passes the notebook's own path — JupyterLab's `NotebookPanel.context.path` — which points at the **`.ipynb` file**, not the folder containing it. Both `color.ts` and `image.ts` interpolated it as though it were a directory:

```ts
`${baseUrl}files/${currentDirectoryPath}/${imagePath}`
```

So a notebook at `PS0/intro.ipynb` referencing `![](diagram.png)` requested:

```
files/PS0/intro.ipynb/diagram.png     ← always 404
```

The image load throws, the `catch` at `color.ts:353` logs it, and **no issue is pushed** — so the check silently reports nothing rather than failing loudly. `image.ts:45-48` has the same bug, which silently disables OCR-based alt-text suggestion for the same images.

Attachment images work because they resolve to a data URL before this branch, which is why the bug looked attachment-specific.

Confirmed there was no `dirname`-style stripping anywhere in `packages/*/src` — the file path was used as a directory at every call site:
- `packages/extension/src/index.ts:55`
- `packages/extension/src/components/mainpanelWidget.ts:181`
- `packages/extension/src/components/fix/base.ts:78`

## Fix

Add `getNotebookDirectory()` and `joinNotebookPath()` to `image-utils.ts` and use them at both sites. The join avoids an empty segment for notebooks at the root.

## Verification

| notebook | image | resolved URL |
|---|---|---|
| `PS0/1 - Intro.ipynb` | `graphIssues3.png` | `files/PS0/graphIssues3.png` |
| `demo.ipynb` | `graphIssues3.png` | `files/graphIssues3.png` |
| `a/b/c/nb.ipynb` | `img/x.png` | `files/a/b/c/img/x.png` |
| `` (empty) | `x.png` | `files/x.png` |

`tsc` clean on core, extension, and CLI.

## Note

This also unblocks #40 — even once jupycheck fetches sibling images into JupyterLite, contrast detection couldn't have loaded them while the directory was wrong.

`packages/cli/dist/` is deliberately **not** included here: rebuilding it is a 13k-line diff that also carries the #89 URL fix, so it belongs in its own PR.